### PR TITLE
Improve getSigner provider validation in transactions.ts

### DIFF
--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -62,7 +62,7 @@ function getSigner(provider: providers.Provider, opts: TxOpts): Signer {
     let signer: Signer;
     if (opts.privateKey && typeof opts.privateKey === 'string' && opts.privateKey.length > 0) {
         signer = new Wallet(opts.privateKey, provider);
-    } else if (provider instanceof providers.Web3Provider) {
+    } else if ((provider.isProvider || provider._isProvider) && provider.getSigner) {
         signer = provider.getSigner();
     } else {
         throw new Error('Invalid provider type, can not send transaction');

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -57,13 +57,14 @@ export async function send(
     return txResponse;
 }
 
-
 function getSigner(provider: providers.Provider, opts: TxOpts): Signer {
     let signer: Signer;
     if (opts.privateKey && typeof opts.privateKey === 'string' && opts.privateKey.length > 0) {
         signer = new Wallet(opts.privateKey, provider);
-    } else if ((provider.isProvider || provider._isProvider) && provider.getSigner) {
-        signer = provider.getSigner();
+    } else if (
+        (provider as providers.Web3Provider)._isProvider
+    ) {
+        signer = (provider as providers.Web3Provider).getSigner();
     } else {
         throw new Error('Invalid provider type, can not send transaction');
     }


### PR DESCRIPTION
**What**: Updating the elimination logic in `transactions.ts` in `getSigner` to be more inclusive and robust.

<!-- Why are these changes necessary? -->

**Why**: For full compatibility with ethers and ethers-based libraries. Issue was raised in https://github.com/skalenetwork/admin-ui when initializing TokenManager classes with an ethers `JsonRpcProvider`, then raised further when passing an ethers `Web3Provider`. Likely cause is the use of `instanceof` as a provider check, where the provider is moving between libraries that are using various different versions of ethers.

<!-- How were these changes implemented? -->

**How**: With a lot of vetting. There's a good chance that the changes have only positive side effects.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

-   [ ] Documentation (not needed)
-   [x] Tests (human tests within `admin-ui`)
-   [x] Ready to be merged
        <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
